### PR TITLE
Add Jupyter notebook example for Kepler experiment tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ pip install kepler
 
 ## Quick Start
 
-### Define and run an experiment
-
 ```python
 from kepler.api import experiment, save_dataframe
 import pandas as pd
@@ -32,71 +30,25 @@ with experiment("my_experiment", {"learning_rate": 0.01, "batch_size": 32}) as e
     exp.log_info("Starting training process")
     
     # Your experiment code here
-    for epoch in range(10):
+    for epoch in range(5):
         # Update progress
-        exp.update_progress(epoch + 1, 10, f"Processing epoch {epoch + 1}/10")
+        exp.update_progress(epoch + 1, 5, f"Processing epoch {epoch + 1}/5")
         
         # Log metrics
-        exp.set_metric(f"accuracy_epoch_{epoch+1}", 0.85 + 0.01 * epoch)
-        exp.set_metric(f"loss_epoch_{epoch+1}", 0.35 - 0.01 * epoch)
+        exp.set_metric(f"accuracy", 0.85 + 0.03 * epoch)
         
-        # Log resource usage
-        exp.log_resource("memory", "250MB")
-    
-    # Save results
-    results = pd.DataFrame({"accuracy": [0.85, 0.87, 0.90], "loss": [0.35, 0.30, 0.25]})
-    df_path = save_dataframe(results, "training_metrics")
-    exp.log_info(f"Saved training metrics to {df_path}")
-    
     # Set final metrics
-    exp.set_metric("final_accuracy", 0.90)
-    exp.set_metric("final_loss", 0.25)
+    exp.set_metric("final_accuracy", 0.95)
 ```
 
-### Examples
+## Examples
 
-Check out the examples directory for more detailed examples:
+Check out the [examples directory](./examples) for more detailed examples:
 - `basic_experiment.py`: A simple example of using Kepler for experiment tracking
 - `multiple_experiments.py`: Running multiple experiments with different configurations
 - `kepler_notebook_example.ipynb`: Using Kepler in a Jupyter notebook environment
 
-### Monitor experiments
-
-Run the TUI to monitor your experiments:
-
-```bash
-kepler tui
-```
-
-## Log-Based Experiment Model
-
-Kepler uses a log-based approach for tracking experiments:
-
-- Each experiment contains a chronological list of log entries
-- Log types include: START, END, PROGRESS, METRIC, ARTIFACT, ERROR, INFO, WARNING, RESOURCE, CONFIG, TAG
-- Experiment properties (status, metrics, config, etc.) are computed from the logs
-- This provides a complete history of the experiment's execution
-
-### Available Log Methods
-
-```python
-# Basic logging
-exp.log_info("Informational message")
-exp.log_warning("Warning message")
-
-# Progress tracking
-exp.update_progress(current=5, total=10, message="Processing batch 5/10")
-
-# Configuration and metrics
-exp.set_config("learning_rate", 0.01)
-exp.set_metric("accuracy", 0.95)
-
-# Resource usage
-exp.log_resource("gpu_memory", "2.5GB")
-
-# Tags
-exp.add_tag("production")
-```
+See the [Examples README](./examples/README.md) for more information.
 
 ## CLI Commands
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ with experiment("my_experiment", {"learning_rate": 0.01, "batch_size": 32}) as e
     exp.set_metric("final_loss", 0.25)
 ```
 
+### Examples
+
+Check out the examples directory for more detailed examples:
+- `basic_experiment.py`: A simple example of using Kepler for experiment tracking
+- `multiple_experiments.py`: Running multiple experiments with different configurations
+- `kepler_notebook_example.ipynb`: Using Kepler in a Jupyter notebook environment
+
 ### Monitor experiments
 
 Run the TUI to monitor your experiments:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,80 @@
+# Kepler Examples
+
+This directory contains examples demonstrating how to use Kepler for experiment tracking and management.
+
+## Available Examples
+
+- `basic_experiment.py`: A simple example of using Kepler for experiment tracking
+- `multiple_experiments.py`: Running multiple experiments with different configurations
+- `kepler_notebook_example.ipynb`: Using Kepler in a Jupyter notebook environment
+
+## Basic Usage
+
+### Define and run an experiment
+
+```python
+from kepler.api import experiment, save_dataframe
+import pandas as pd
+
+# Define and run an experiment
+with experiment("my_experiment", {"learning_rate": 0.01, "batch_size": 32}) as exp:
+    # Log some information
+    exp.log_info("Starting training process")
+    
+    # Your experiment code here
+    for epoch in range(10):
+        # Update progress
+        exp.update_progress(epoch + 1, 10, f"Processing epoch {epoch + 1}/10")
+        
+        # Log metrics
+        exp.set_metric(f"accuracy_epoch_{epoch+1}", 0.85 + 0.01 * epoch)
+        exp.set_metric(f"loss_epoch_{epoch+1}", 0.35 - 0.01 * epoch)
+        
+        # Log resource usage
+        exp.log_resource("memory", "250MB")
+    
+    # Save results
+    results = pd.DataFrame({"accuracy": [0.85, 0.87, 0.90], "loss": [0.35, 0.30, 0.25]})
+    df_path = save_dataframe(results, "training_metrics")
+    exp.log_info(f"Saved training metrics to {df_path}")
+    
+    # Set final metrics
+    exp.set_metric("final_accuracy", 0.90)
+    exp.set_metric("final_loss", 0.25)
+```
+
+### Monitor experiments
+
+Run the TUI to monitor your experiments:
+
+```bash
+kepler tui
+```
+
+## Available Log Methods
+
+```python
+# Basic logging
+exp.log_info("Informational message")
+exp.log_warning("Warning message")
+
+# Progress tracking
+exp.update_progress(current=5, total=10, message="Processing batch 5/10")
+
+# Configuration and metrics
+exp.set_config("learning_rate", 0.01)
+exp.set_metric("accuracy", 0.95)
+
+# Resource usage
+exp.log_resource("gpu_memory", "2.5GB")
+
+# Tags
+exp.add_tag("production")
+```
+
+## CLI Commands
+
+- `kepler tui`: Launch the terminal UI for monitoring experiments
+- `kepler list`: List all experiments
+- `kepler info <experiment_id>`: Show detailed information about an experiment
+- `kepler clean`: Clean up old or failed experiments

--- a/examples/kepler_notebook_example.ipynb
+++ b/examples/kepler_notebook_example.ipynb
@@ -1,0 +1,432 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Kepler Experiment Management - Jupyter Notebook Example\n",
+    "\n",
+    "This notebook demonstrates how to use Kepler for experiment tracking and management in a Jupyter notebook environment. Kepler provides tools for defining experiment configurations, saving results, and monitoring progress."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "First, let's import the necessary libraries:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "import time\n",
+    "import random\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from sklearn.datasets import make_classification\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.metrics import accuracy_score, precision_score, recall_score, f1_score\n",
+    "\n",
+    "# Import Kepler\n",
+    "from kepler import experiment, save_dataframe, save_dict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate Synthetic Data\n",
+    "\n",
+    "Let's create a synthetic classification dataset for our experiments:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Generate a synthetic classification dataset\n",
+    "X, y = make_classification(\n",
+    "    n_samples=1000,\n",
+    "    n_features=20,\n",
+    "    n_informative=10,\n",
+    "    n_redundant=5,\n",
+    "    random_state=42\n",
+    ")\n",
+    "\n",
+    "# Split the data into training and testing sets\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)\n",
+    "\n",
+    "print(f\"Training data shape: {X_train.shape}\")\n",
+    "print(f\"Testing data shape: {X_test.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define Experiment Configuration\n",
+    "\n",
+    "Now, let's define the configuration for our experiment:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Define experiment configuration\n",
+    "config = {\n",
+    "    \"model\": \"RandomForest\",\n",
+    "    \"n_estimators\": 100,\n",
+    "    \"max_depth\": 10,\n",
+    "    \"min_samples_split\": 2,\n",
+    "    \"min_samples_leaf\": 1,\n",
+    "    \"random_state\": 42\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run the Experiment\n",
+    "\n",
+    "Now we'll run our experiment using Kepler's experiment context manager:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Run the experiment\n",
+    "with experiment(\"RandomForest-Notebook\", config=config, tags=[\"notebook\", \"classification\"]) as exp:\n",
+    "    exp.log_info(\"Starting RandomForest training experiment\")\n",
+    "    \n",
+    "    # Initialize the model with our configuration\n",
+    "    model = RandomForestClassifier(\n",
+    "        n_estimators=config[\"n_estimators\"],\n",
+    "        max_depth=config[\"max_depth\"],\n",
+    "        min_samples_split=config[\"min_samples_split\"],\n",
+    "        min_samples_leaf=config[\"min_samples_leaf\"],\n",
+    "        random_state=config[\"random_state\"]\n",
+    "    )\n",
+    "    \n",
+    "    # Log the start of training\n",
+    "    exp.log_info(\"Training model...\")\n",
+    "    exp.update_progress(0, 3, \"Starting model training\")\n",
+    "    \n",
+    "    # Train the model\n",
+    "    start_time = time.time()\n",
+    "    model.fit(X_train, y_train)\n",
+    "    training_time = time.time() - start_time\n",
+    "    \n",
+    "    # Log training completion\n",
+    "    exp.log_info(f\"Model training completed in {training_time:.2f} seconds\")\n",
+    "    exp.update_progress(1, 3, \"Model training completed\")\n",
+    "    exp.set_metric(\"training_time\", training_time)\n",
+    "    \n",
+    "    # Make predictions\n",
+    "    exp.log_info(\"Making predictions on test data...\")\n",
+    "    y_pred = model.predict(X_test)\n",
+    "    exp.update_progress(2, 3, \"Predictions generated\")\n",
+    "    \n",
+    "    # Calculate metrics\n",
+    "    exp.log_info(\"Calculating performance metrics...\")\n",
+    "    metrics = {\n",
+    "        \"accuracy\": accuracy_score(y_test, y_pred),\n",
+    "        \"precision\": precision_score(y_test, y_pred),\n",
+    "        \"recall\": recall_score(y_test, y_pred),\n",
+    "        \"f1_score\": f1_score(y_test, y_pred)\n",
+    "    }\n",
+    "    \n",
+    "    # Log all metrics\n",
+    "    for metric_name, metric_value in metrics.items():\n",
+    "        exp.set_metric(metric_name, metric_value)\n",
+    "    \n",
+    "    # Log feature importances\n",
+    "    feature_importances = model.feature_importances_\n",
+    "    feature_importance_df = pd.DataFrame({\n",
+    "        'feature': [f'feature_{i}' for i in range(X.shape[1])],\n",
+    "        'importance': feature_importances\n",
+    "    }).sort_values('importance', ascending=False)\n",
+    "    \n",
+    "    # Save feature importances\n",
+    "    fi_path = save_dataframe(feature_importance_df, \"feature_importances\", exp.id)\n",
+    "    exp.log_info(f\"Saved feature importances to {fi_path}\")\n",
+    "    \n",
+    "    # Save metrics\n",
+    "    metrics_path = save_dict(metrics, \"performance_metrics\", exp.id)\n",
+    "    exp.log_info(f\"Saved performance metrics to {metrics_path}\")\n",
+    "    \n",
+    "    # Complete the experiment\n",
+    "    exp.update_progress(3, 3, \"Experiment completed\")\n",
+    "    exp.log_info(\"Experiment completed successfully\")\n",
+    "    \n",
+    "    # Display results\n",
+    "    print(f\"Experiment ID: {exp.id}\")\n",
+    "    print(\"Performance Metrics:\")\n",
+    "    for metric_name, metric_value in metrics.items():\n",
+    "        print(f\"  {metric_name}: {metric_value:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize Results\n",
+    "\n",
+    "Now let's visualize some of the results from our experiment:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Plot feature importances\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "plt.barh(feature_importance_df['feature'][:10], feature_importance_df['importance'][:10])\n",
+    "plt.xlabel('Importance')\n",
+    "plt.ylabel('Feature')\n",
+    "plt.title('Top 10 Feature Importances')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Plot metrics\n",
+    "plt.figure(figsize=(8, 6))\n",
+    "plt.bar(metrics.keys(), metrics.values())\n",
+    "plt.ylim(0, 1)\n",
+    "plt.title('Model Performance Metrics')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Running Multiple Experiments\n",
+    "\n",
+    "Let's run multiple experiments with different hyperparameters to compare their performance:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Define hyperparameter grid\n",
+    "param_grid = [\n",
+    "    {\"n_estimators\": 50, \"max_depth\": 5},\n",
+    "    {\"n_estimators\": 100, \"max_depth\": 10},\n",
+    "    {\"n_estimators\": 200, \"max_depth\": 15}\n",
+    "]\n",
+    "\n",
+    "# Store results for comparison\n",
+    "experiment_results = []\n",
+    "\n",
+    "# Run experiments for each parameter combination\n",
+    "for i, params in enumerate(param_grid):\n",
+    "    # Update the configuration\n",
+    "    config = {\n",
+    "        \"model\": \"RandomForest\",\n",
+    "        \"n_estimators\": params[\"n_estimators\"],\n",
+    "        \"max_depth\": params[\"max_depth\"],\n",
+    "        \"min_samples_split\": 2,\n",
+    "        \"min_samples_leaf\": 1,\n",
+    "        \"random_state\": 42\n",
+    "    }\n",
+    "    \n",
+    "    # Create experiment name\n",
+    "    exp_name = f\"RF-NE{params['n_estimators']}-MD{params['max_depth']}\"\n",
+    "    \n",
+    "    # Run the experiment\n",
+    "    with experiment(exp_name, config=config, tags=[\"notebook\", \"hyperparameter_tuning\"]) as exp:\n",
+    "        exp.log_info(f\"Starting experiment {i+1}/{len(param_grid)}\")\n",
+    "        \n",
+    "        # Initialize and train the model\n",
+    "        model = RandomForestClassifier(\n",
+    "            n_estimators=config[\"n_estimators\"],\n",
+    "            max_depth=config[\"max_depth\"],\n",
+    "            min_samples_split=config[\"min_samples_split\"],\n",
+    "            min_samples_leaf=config[\"min_samples_leaf\"],\n",
+    "            random_state=config[\"random_state\"]\n",
+    "        )\n",
+    "        \n",
+    "        # Train the model\n",
+    "        start_time = time.time()\n",
+    "        model.fit(X_train, y_train)\n",
+    "        training_time = time.time() - start_time\n",
+    "        exp.set_metric(\"training_time\", training_time)\n",
+    "        \n",
+    "        # Make predictions and calculate metrics\n",
+    "        y_pred = model.predict(X_test)\n",
+    "        metrics = {\n",
+    "            \"accuracy\": accuracy_score(y_test, y_pred),\n",
+    "            \"precision\": precision_score(y_test, y_pred),\n",
+    "            \"recall\": recall_score(y_test, y_pred),\n",
+    "            \"f1_score\": f1_score(y_test, y_pred)\n",
+    "        }\n",
+    "        \n",
+    "        # Log metrics\n",
+    "        for metric_name, metric_value in metrics.items():\n",
+    "            exp.set_metric(metric_name, metric_value)\n",
+    "        \n",
+    "        # Save metrics\n",
+    "        save_dict(metrics, \"performance_metrics\", exp.id)\n",
+    "        \n",
+    "        # Store results for comparison\n",
+    "        result = {\n",
+    "            \"experiment_id\": exp.id,\n",
+    "            \"experiment_name\": exp_name,\n",
+    "            \"n_estimators\": params[\"n_estimators\"],\n",
+    "            \"max_depth\": params[\"max_depth\"],\n",
+    "            \"training_time\": training_time,\n",
+    "            **metrics\n",
+    "        }\n",
+    "        experiment_results.append(result)\n",
+    "        \n",
+    "        print(f\"Completed experiment: {exp_name} (ID: {exp.id})\")\n",
+    "        print(f\"Accuracy: {metrics['accuracy']:.4f}, Training time: {training_time:.2f}s\")\n",
+    "        print(\"-\" * 50)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compare Experiment Results\n",
+    "\n",
+    "Let's create a DataFrame to compare the results of our experiments:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Create a DataFrame with the results\n",
+    "results_df = pd.DataFrame(experiment_results)\n",
+    "results_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Visualize the comparison of accuracy across experiments\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "plt.bar(results_df['experiment_name'], results_df['accuracy'])\n",
+    "plt.ylim(0.8, 1.0)  # Adjust as needed\n",
+    "plt.ylabel('Accuracy')\n",
+    "plt.title('Accuracy Comparison Across Experiments')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Visualize the trade-off between accuracy and training time\n",
+    "plt.figure(figsize=(10, 6))\n",
+    "plt.scatter(results_df['training_time'], results_df['accuracy'], s=100)\n",
+    "\n",
+    "# Add labels to each point\n",
+    "for i, row in results_df.iterrows():\n",
+    "    plt.annotate(row['experiment_name'], \n",
+    "                 (row['training_time'], row['accuracy']),\n",
+    "                 textcoords=\"offset points\", \n",
+    "                 xytext=(0,10), \n",
+    "                 ha='center')\n",
+    "\n",
+    "plt.xlabel('Training Time (seconds)')\n",
+    "plt.ylabel('Accuracy')\n",
+    "plt.title('Accuracy vs. Training Time')\n",
+    "plt.grid(True, linestyle='--', alpha=0.7)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "In this notebook, we've demonstrated how to use Kepler for experiment tracking in a Jupyter notebook environment. We've shown how to:\n",
+    "\n",
+    "1. Define experiment configurations\n",
+    "2. Track experiment progress and log metrics\n",
+    "3. Save experiment artifacts (DataFrames and dictionaries)\n",
+    "4. Run multiple experiments with different hyperparameters\n",
+    "5. Compare and visualize experiment results\n",
+    "\n",
+    "Kepler makes it easy to keep track of your experiments, their configurations, and results, which is essential for reproducible data science workflows."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next Steps\n",
+    "\n",
+    "You can view your experiments using the Kepler terminal UI by running the following command in a terminal:\n",
+    "\n",
+    "```bash\n",
+    "kepler tui\n",
+    "```\n",
+    "\n",
+    "Or list all experiments with:\n",
+    "\n",
+    "```bash\n",
+    "kepler list\n",
+    "```\n",
+    "\n",
+    "For more information about a specific experiment, use:\n",
+    "\n",
+    "```bash\n",
+    "kepler info <experiment_id>\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Description
This PR adds a Jupyter notebook example to demonstrate how to use Kepler for experiment tracking in a notebook environment. It also reorganizes documentation by creating a dedicated README in the examples directory.

## Changes
- Added `kepler_notebook_example.ipynb` in the examples directory
- Created `examples/README.md` with detailed usage examples and documentation
- Simplified the main README.md and added references to the examples directory

## Features
The notebook example demonstrates:
- Setting up and running experiments with Kepler in a Jupyter environment
- Tracking experiment progress and logging metrics
- Saving experiment artifacts (DataFrames and dictionaries)
- Running multiple experiments with different hyperparameters
- Comparing and visualizing experiment results

This example will help users understand how to integrate Kepler into their data science workflows using Jupyter notebooks.