### PR TITLE
Refactor: Move experiment log code to separate module

### DIFF
--- a/kepler/models/__init__.py
+++ b/kepler/models/__init__.py
@@ -4,8 +4,10 @@ Models for experiment management.
 from kepler.models.experiment import (
     Experiment, 
     ExperimentList, 
-    ExperimentStatus, 
-    ExperimentLog, 
+    ExperimentStatus
+)
+from kepler.models.log import (
+    ExperimentLog,
     LogType
 )
 from kepler.models.storage import (

--- a/kepler/models/experiment.py
+++ b/kepler/models/experiment.py
@@ -9,6 +9,8 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
 
+from kepler.models.log import ExperimentLog, LogType
+
 
 class ExperimentStatus(str, Enum):
     """Status of an experiment."""
@@ -19,118 +21,6 @@ class ExperimentStatus(str, Enum):
     INTERRUPTED = "interrupted"
 
 
-class LogType(str, Enum):
-    """Type of log entry."""
-
-    START = "start"
-    END = "end"
-    PROGRESS = "progress"
-    METRIC = "metric"
-    ARTIFACT = "artifact"
-    ERROR = "error"
-    INFO = "info"
-    WARNING = "warning"
-    RESOURCE = "resource"
-    CONFIG = "config"
-    TAG = "tag"
-
-
-class ExperimentLog(BaseModel):
-    """
-    Log entry for an experiment.
-    """
-
-    timestamp: datetime = Field(default_factory=datetime.now)
-    type: LogType
-    message: str
-    data: Dict[str, Any] = Field(default_factory=dict)
-
-    @classmethod
-    def start(cls, message: str = "Experiment started") -> "ExperimentLog":
-        """Create a start log entry."""
-        return cls(type=LogType.START, message=message)
-
-    @classmethod
-    def end(cls, message: str = "Experiment completed") -> "ExperimentLog":
-        """Create an end log entry."""
-        return cls(type=LogType.END, message=message)
-
-    @classmethod
-    def progress(cls, current: int, total: int, message: str = "") -> "ExperimentLog":
-        """Create a progress log entry."""
-        return cls(
-            type=LogType.PROGRESS,
-            message=message or f"Progress: {current}/{total}",
-            data={
-                "current": current,
-                "total": total,
-                "percentage": current / total * 100,
-            },
-        )
-
-    @classmethod
-    def metric(cls, name: str, value: Any) -> "ExperimentLog":
-        """Create a metric log entry."""
-        return cls(
-            type=LogType.METRIC,
-            message=f"Metric: {name} = {value}",
-            data={"name": name, "value": value},
-        )
-
-    @classmethod
-    def artifact(cls, name: str, path: Path) -> "ExperimentLog":
-        """Create an artifact log entry."""
-        return cls(
-            type=LogType.ARTIFACT,
-            message=f"Artifact saved: {name} at {path}",
-            data={"name": name, "path": path},
-        )
-
-    @classmethod
-    def error(
-        cls, message: str, error_details: Optional[str] = None
-    ) -> "ExperimentLog":
-        """Create an error log entry."""
-        return cls(
-            type=LogType.ERROR,
-            message=message,
-            data={"error_details": error_details} if error_details else {},
-        )
-
-    @classmethod
-    def info(cls, message: str) -> "ExperimentLog":
-        """Create an info log entry."""
-        return cls(type=LogType.INFO, message=message)
-
-    @classmethod
-    def warning(cls, message: str) -> "ExperimentLog":
-        """Create a warning log entry."""
-        return cls(type=LogType.WARNING, message=message)
-
-    @classmethod
-    def resource(cls, resource_type: str, usage: Any) -> "ExperimentLog":
-        """Create a resource usage log entry."""
-        return cls(
-            type=LogType.RESOURCE,
-            message=f"Resource usage: {resource_type} = {usage}",
-            data={"resource_type": resource_type, "usage": usage},
-        )
-
-    @classmethod
-    def config(cls, key: str, value: Any) -> "ExperimentLog":
-        """Create a config log entry."""
-        return cls(
-            type=LogType.CONFIG,
-            message=f"Config: {key} = {value}",
-            data={"key": key, "value": value},
-        )
-
-    @classmethod
-    def tag(cls, tag: str) -> "ExperimentLog":
-        """Create a tag log entry."""
-        return cls(type=LogType.TAG, message=f"Tag added: {tag}", data={"tag": tag})
-
-
 class Experiment(BaseModel):
     """
     Model representing an experiment.
@@ -139,6 +29,21 @@ class Experiment(BaseModel):
     id: str
     name: str
     logs: List[ExperimentLog] = Field(default_factory=list)
+    
+    def __init__(self, **data):
+        # Extract tags if present
+        tags = data.pop('tags', None)
+        
+        super().__init__(**data)
+        
+        # Add a start log if there are no logs yet
+        if not self.logs:
+            self.start()
+            
+        # Add tags if provided
+        if tags:
+            for tag in tags:
+                self.add_tag(tag)
 
     @property
     def status(self) -> ExperimentStatus:

--- a/kepler/models/log.py
+++ b/kepler/models/log.py
@@ -1,0 +1,122 @@
+"""
+Log model definitions for experiments.
+"""
+
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class LogType(str, Enum):
+    """Type of log entry."""
+
+    START = "start"
+    END = "end"
+    PROGRESS = "progress"
+    METRIC = "metric"
+    ARTIFACT = "artifact"
+    ERROR = "error"
+    INFO = "info"
+    WARNING = "warning"
+    RESOURCE = "resource"
+    CONFIG = "config"
+    TAG = "tag"
+
+
+class ExperimentLog(BaseModel):
+    """
+    Log entry for an experiment.
+    """
+
+    timestamp: datetime = Field(default_factory=datetime.now)
+    type: LogType
+    message: str
+    data: Dict[str, Any] = Field(default_factory=dict)
+
+    @classmethod
+    def start(cls, message: str = "Experiment started") -> "ExperimentLog":
+        """Create a start log entry."""
+        return cls(type=LogType.START, message=message)
+
+    @classmethod
+    def end(cls, message: str = "Experiment completed") -> "ExperimentLog":
+        """Create an end log entry."""
+        return cls(type=LogType.END, message=message)
+
+    @classmethod
+    def progress(cls, current: int, total: int, message: str = "") -> "ExperimentLog":
+        """Create a progress log entry."""
+        return cls(
+            type=LogType.PROGRESS,
+            message=message or f"Progress: {current}/{total}",
+            data={
+                "current": current,
+                "total": total,
+                "percentage": current / total * 100,
+            },
+        )
+
+    @classmethod
+    def metric(cls, name: str, value: Any) -> "ExperimentLog":
+        """Create a metric log entry."""
+        return cls(
+            type=LogType.METRIC,
+            message=f"Metric: {name} = {value}",
+            data={"name": name, "value": value},
+        )
+
+    @classmethod
+    def artifact(cls, name: str, path: Path) -> "ExperimentLog":
+        """Create an artifact log entry."""
+        return cls(
+            type=LogType.ARTIFACT,
+            message=f"Artifact saved: {name} at {path}",
+            data={"name": name, "path": path},
+        )
+
+    @classmethod
+    def error(
+        cls, message: str, error_details: Optional[str] = None
+    ) -> "ExperimentLog":
+        """Create an error log entry."""
+        return cls(
+            type=LogType.ERROR,
+            message=message,
+            data={"error_details": error_details} if error_details else {},
+        )
+
+    @classmethod
+    def info(cls, message: str) -> "ExperimentLog":
+        """Create an info log entry."""
+        return cls(type=LogType.INFO, message=message)
+
+    @classmethod
+    def warning(cls, message: str) -> "ExperimentLog":
+        """Create a warning log entry."""
+        return cls(type=LogType.WARNING, message=message)
+
+    @classmethod
+    def resource(cls, resource_type: str, usage: Any) -> "ExperimentLog":
+        """Create a resource usage log entry."""
+        return cls(
+            type=LogType.RESOURCE,
+            message=f"Resource usage: {resource_type} = {usage}",
+            data={"resource_type": resource_type, "usage": usage},
+        )
+
+    @classmethod
+    def config(cls, key: str, value: Any) -> "ExperimentLog":
+        """Create a config log entry."""
+        return cls(
+            type=LogType.CONFIG,
+            message=f"Config: {key} = {value}",
+            data={"key": key, "value": value},
+        )
+
+    @classmethod
+    def tag(cls, tag: str) -> "ExperimentLog":
+        """Create a tag log entry."""
+        return cls(type=LogType.TAG, message=f"Tag added: {tag}", data={"tag": tag})

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -162,7 +162,7 @@ class TestExperimentList:
 def mock_app_dir():
     """Fixture to mock the application directory."""
     with tempfile.TemporaryDirectory() as temp_dir:
-        with patch("expman.models.storage.get_app_dir", return_value=Path(temp_dir)):
+        with patch("kepler.models.storage.get_app_dir", return_value=Path(temp_dir)):
             yield temp_dir
 
 


### PR DESCRIPTION
## Description
This PR moves the experiment log code from `experiment.py` to a new `log.py` module to improve code organization and maintainability.

## Changes
- Created new `log.py` file in the models directory with the log-related code
- Moved `LogType` enum and `ExperimentLog` class from `experiment.py` to `log.py`
- Updated imports in `experiment.py` to use the new module
- Updated `__init__.py` to import from the new module
- Fixed failing test by adding initialization code to create a start log when an experiment is created
- Added support for initializing experiments with tags

## Testing
All tests are passing.